### PR TITLE
feat: add CodexCurator LWC app

### DIFF
--- a/force-app/main/default/classes/CodexCuratorController.cls
+++ b/force-app/main/default/classes/CodexCuratorController.cls
@@ -1,0 +1,51 @@
+public with sharing class CodexCuratorController {
+  public class FieldInfo {
+    @AuraEnabled
+    public String apiName;
+    @AuraEnabled
+    public String label;
+  }
+
+  @AuraEnabled(cacheable=true)
+  public static List<FieldInfo> getFieldOptions() {
+    Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe()
+      .get('Employee_Survey__c')
+      .getDescribe()
+      .fields.getMap();
+    List<FieldInfo> options = new List<FieldInfo>();
+    for (String fieldName : fieldMap.keySet()) {
+      if (fieldName == 'Name' || fieldName == 'Id') {
+        continue;
+      }
+      Schema.DescribeFieldResult d = fieldMap.get(fieldName).getDescribe();
+      FieldInfo info = new FieldInfo();
+      info.apiName = fieldName;
+      info.label = d.getLabel();
+      options.add(info);
+    }
+    return options;
+  }
+
+  @AuraEnabled(cacheable=true)
+  public static List<Map<String, Object>> getRecords(List<String> fields) {
+    Set<String> fieldSet = new Set<String>();
+    if (fields != null) {
+      fieldSet.addAll(fields);
+    }
+    String query = 'SELECT Id, Name';
+    for (String f : fieldSet) {
+      query += ', ' + f;
+    }
+    query += ' FROM Employee_Survey__c';
+    List<SObject> records = Database.query(query);
+    List<Map<String, Object>> results = new List<Map<String, Object>>();
+    for (SObject s : records) {
+      Map<String, Object> row = s.getPopulatedFieldsAsMap();
+      if (!row.containsKey('Id')) {
+        row.put('Id', s.Id);
+      }
+      results.add(row);
+    }
+    return results;
+  }
+}

--- a/force-app/main/default/classes/CodexCuratorController.cls-meta.xml
+++ b/force-app/main/default/classes/CodexCuratorController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/codexCurator/__tests__/codexCurator.test.js
+++ b/force-app/main/default/lwc/codexCurator/__tests__/codexCurator.test.js
@@ -1,0 +1,51 @@
+import { createElement } from "lwc";
+import CodexCurator from "c/codexCurator";
+import getFieldOptions from "@salesforce/apex/CodexCuratorController.getFieldOptions";
+import getRecords from "@salesforce/apex/CodexCuratorController.getRecords";
+
+jest.mock(
+  "@salesforce/apex/CodexCuratorController.getFieldOptions",
+  () => {
+    return { default: jest.fn() };
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  "@salesforce/apex/CodexCuratorController.getRecords",
+  () => {
+    return { default: jest.fn() };
+  },
+  { virtual: true }
+);
+
+function flushPromises() {
+  return Promise.resolve();
+}
+
+describe("c-codex-curator", () => {
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    jest.clearAllMocks();
+  });
+
+  it("renders datatable with Name column by default", async () => {
+    getFieldOptions.mockResolvedValue([]);
+    getRecords.mockResolvedValue([{ Id: "1", Name: "Test" }]);
+
+    const element = createElement("c-codex-curator", {
+      is: CodexCurator
+    });
+    document.body.appendChild(element);
+
+    await flushPromises();
+    await flushPromises();
+
+    const datatable = element.shadowRoot.querySelector("lightning-datatable");
+    expect(datatable).not.toBeNull();
+    expect(datatable.columns[0].label).toBe("Name");
+    expect(datatable.data.length).toBe(1);
+  });
+});

--- a/force-app/main/default/lwc/codexCurator/codexCurator.html
+++ b/force-app/main/default/lwc/codexCurator/codexCurator.html
@@ -1,0 +1,50 @@
+<template>
+  <lightning-card title="Codex Curator">
+    <div class="slds-m-around_medium">
+      <lightning-button
+        label="Configure Fields"
+        onclick={handleConfigure}
+      ></lightning-button>
+    </div>
+    <lightning-datatable
+      key-field="Id"
+      data={data}
+      columns={columns}
+    ></lightning-datatable>
+  </lightning-card>
+
+  <template if:true={modalOpen}>
+    <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+      <div class="slds-modal__container">
+        <header class="slds-modal__header">
+          <h2 class="slds-text-heading_medium">Select Fields</h2>
+        </header>
+        <div class="slds-modal__content slds-p-around_medium">
+          <lightning-dual-listbox
+            name="fields"
+            label="Select Fields"
+            source-label="Available"
+            selected-label="Displayed"
+            field-level-help="Select additional fields to display"
+            options={fieldOptions}
+            value={selectedFields}
+            onchange={handleFieldChange}
+          ></lightning-dual-listbox>
+        </div>
+        <footer class="slds-modal__footer">
+          <lightning-button
+            variant="neutral"
+            label="Cancel"
+            onclick={handleCancel}
+          ></lightning-button>
+          <lightning-button
+            variant="brand"
+            label="Save"
+            onclick={handleSave}
+          ></lightning-button>
+        </footer>
+      </div>
+    </section>
+    <div class="slds-backdrop slds-backdrop_open"></div>
+  </template>
+</template>

--- a/force-app/main/default/lwc/codexCurator/codexCurator.js
+++ b/force-app/main/default/lwc/codexCurator/codexCurator.js
@@ -1,0 +1,63 @@
+import { LightningElement } from "lwc";
+import getFieldOptions from "@salesforce/apex/CodexCuratorController.getFieldOptions";
+import getRecords from "@salesforce/apex/CodexCuratorController.getRecords";
+
+export default class CodexCurator extends LightningElement {
+  data = [];
+  columns = [{ label: "Name", fieldName: "Name" }];
+  allFields = [];
+  selectedFields = [];
+  modalOpen = false;
+
+  connectedCallback() {
+    this.loadFieldOptions();
+    this.loadData();
+  }
+
+  loadFieldOptions() {
+    getFieldOptions()
+      .then((result) => {
+        this.allFields = result;
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  loadData() {
+    getRecords({ fields: this.selectedFields })
+      .then((result) => {
+        this.data = result;
+        const cols = [{ label: "Name", fieldName: "Name" }];
+        this.selectedFields.forEach((f) => {
+          const opt = this.allFields.find((o) => o.apiName === f);
+          cols.push({ label: opt ? opt.label : f, fieldName: f });
+        });
+        this.columns = cols;
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  handleConfigure() {
+    this.modalOpen = true;
+  }
+
+  handleFieldChange(event) {
+    this.selectedFields = event.detail.value;
+  }
+
+  handleSave() {
+    this.modalOpen = false;
+    this.loadData();
+  }
+
+  handleCancel() {
+    this.modalOpen = false;
+  }
+
+  get fieldOptions() {
+    return this.allFields.map((f) => ({ label: f.label, value: f.apiName }));
+  }
+}

--- a/force-app/main/default/lwc/codexCurator/codexCurator.js-meta.xml
+++ b/force-app/main/default/lwc/codexCurator/codexCurator.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add CodexCurator Apex controller exposing field metadata and dynamic record retrieval
- implement CodexCurator LWC with configurable columns and selection modal
- cover component with a basic Jest unit test

## Testing
- `npm test`
- `npm run lint`
- `npm run prettier:verify` *(shows existing style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689dbe031ac883279f2bb8a2e3a3fb4d